### PR TITLE
Change the old ULR of Google Python Style Guide

### DIFF
--- a/pythoncz/templates/beginners_cs.html
+++ b/pythoncz/templates/beginners_cs.html
@@ -196,7 +196,7 @@
         <ul>
             <li><a href="http://www.python.org/dev/peps/pep-0008/">Style Guide for Python Code</a></li>
             <li><a href="http://www.python.org/dev/peps/pep-0257/">Python Docstring Conventions</a></li>
-            <li><a href="http://google-styleguide.googlecode.com/svn/trunk/pyguide.html">Google Python Style Guide</a></li>
+            <li><a href="https://google.github.io/styleguide/pyguide.html">Google Python Style Guide</a></li>
         </ul>
 
         <h3>


### PR DESCRIPTION
There is a broken link to Google Python Style Guide. I found the new one.