### PR TITLE
Fix missing dash

### DIFF
--- a/pythoncz/views.py
+++ b/pythoncz/views.py
@@ -82,6 +82,6 @@ def talks(target):
     return redirect(base_url + target, code=301)
 
 
-@app.route('/zapojse')
+@app.route('/zapojse/')
 def get_involved():
     return redirect(app.config['GET_INVOLVED_URL'])


### PR DESCRIPTION
without it /zapojse/ won't redirect, only /zapojse