### PR TITLE
Use https: instead of http: in some places

### DIFF
--- a/pythoncz/models/github.py
+++ b/pythoncz/models/github.py
@@ -30,7 +30,7 @@ def get_issues(org_names):
 def _get_issues_for_org(org_name):
     now = datetime.now()
     user_agent = ('pythoncz/{now.year}-{now.month} '
-                  '(+http://python.cz)').format(now=now)
+                  '(+https://python.cz)').format(now=now)
 
     session = requests.Session()
     session.headers.update({

--- a/pythoncz/templates/_base.html
+++ b/pythoncz/templates/_base.html
@@ -129,7 +129,7 @@
             {% endif %}
             </div>
 
-            <script src="http://code.jquery.com/jquery-1.10.1.min.js"></script>
+            <script src="https://code.jquery.com/jquery-1.10.1.min.js"></script>
             <script src="{{ url_for('static', filename='permalinks.js') }}"></script>
             {% block scripts %}{% endblock %}
         </div>

--- a/pythoncz/templates/get_involved_cs.html
+++ b/pythoncz/templates/get_involved_cs.html
@@ -72,10 +72,10 @@
       <div class="col-md-8 col-md-offset-2">
         <ul>
             <li>
-                Přihlaš se s přednáškou na nejbližší <a href="http://pyvo.cz">sraz</a>.
+                Přihlaš se s přednáškou na nejbližší <a href="https://pyvo.cz">sraz</a>.
             </li>
             <li>
-                Pokud se necítíš na 15-20 minut, připrav si tzv. lightning talk. Je to pětiminutovka o čemkoliv a můžeš s ní přijít na <a href="http://pyvo.cz">srazy</a> přijít i bez ohlášení.
+                Pokud se necítíš na 15-20 minut, připrav si tzv. lightning talk. Je to pětiminutovka o čemkoliv a můžeš s ní přijít na <a href="https://pyvo.cz">srazy</a> přijít i bez ohlášení.
             </li>
             <li>
                 Koukni se, jestli zrovna nehledají řečníky <a href="https://cz.pycon.org/">PyCon&nbsp;CZ</a> nebo <a href="https://www.pycon.sk/">PyCon&nbsp;SK</a>. Na mnohé konference se může přihlásit s přednáškou kdokoliv, stačí vyplnit formulář &ndash; tzv. CfP (Call for Proposals).

--- a/pythoncz/templates/index_cs.html
+++ b/pythoncz/templates/index_cs.html
@@ -46,7 +46,7 @@
                 <div class="col-md-6 col-md-offset-3 meetups">
                     <h2>Srazy</h2>
                     <p>
-                        <a href="http://pyvo.cz">Srazy Python programátorů</a> zvané <strong>Pyvo</strong> se pořádají po celé republice. Přijď si poslechnout <strong>přednášky</strong> od chytrých lidí a <strong>popovídat si</strong> nejen o Pythonu!
+                        <a href="https://pyvo.cz">Srazy Python programátorů</a> zvané <strong>Pyvo</strong> se pořádají po celé republice. Přijď si poslechnout <strong>přednášky</strong> od chytrých lidí a <strong>popovídat si</strong> nejen o Pythonu!
                     </p>
                     {% include '_meetups.html' %}
                 </div>

--- a/pythoncz/templates/jobs_cs.html
+++ b/pythoncz/templates/jobs_cs.html
@@ -6,7 +6,7 @@
     <meta name="description" content="Kdo v ČR používá Python? Má smysl se učit Python? Jak seženu Python vývojáře? Jak seženu práci v Pythonu?">
     <meta property="og:description" content="Kdo v ČR používá Python? Má smysl se učit Python? Jak seženu Python vývojáře? Jak seženu práci v Pythonu?">
 
-    <link rel="stylesheet" href="http://cdn.leafletjs.com/leaflet-0.7.2/leaflet.css" />
+    <link rel="stylesheet" href="https://unpkg.com/leaflet@1.0.2/dist/leaflet.css" />
 {% endblock %}
 
 {% block body_class %}jobs{% endblock %}
@@ -142,7 +142,7 @@
     </div>
 
     {% block scripts %}
-        <script src="http://cdn.leafletjs.com/leaflet-0.7.2/leaflet.js"></script>
+        <script src="https://unpkg.com/leaflet@1.0.2/dist/leaflet.js"></script>
         <script src="{{ url_for('static', filename='maps.js') }}"></script>
     {% endblock %}
 {% endblock %}

--- a/pythoncz/templates/jobs_en.html
+++ b/pythoncz/templates/jobs_en.html
@@ -6,7 +6,7 @@
     <meta name="description" content="Who uses Python in the Czech Republic? How to find Czech Python software engineers?">
     <meta property="og:description" content="Who uses Python in the Czech Republic? How to find Czech Python software engineers?">
 
-    <link rel="stylesheet" href="http://cdn.leafletjs.com/leaflet-0.7.2/leaflet.css" />
+    <link rel="stylesheet" href="https://unpkg.com/leaflet@1.0.2/dist/leaflet.css" />
 {% endblock %}
 
 {% block body_class %}jobs{% endblock %}
@@ -101,7 +101,7 @@
     </div>
 
     {% block scripts %}
-        <script src="http://cdn.leafletjs.com/leaflet-0.7.2/leaflet.js"></script>
+        <script src="https://unpkg.com/leaflet@1.0.2/dist/leaflet.js"></script>
         <script src="{{ url_for('static', filename='maps.js') }}"></script>
     {% endblock %}
 {% endblock %}


### PR DESCRIPTION
- Update Leaflet to 1.0.2. The old CDN doesn't support HTTPS, so I copied the
current URLs from the Leaflet site and checked it still works.

- Update JQuery URL to HTTPS. This should help prevent mixed-content warnings.

- Switch links to pyvo.cz to use HTTPS.

Related: https://github.com/pyvec/python.cz/issues/92