### PR TITLE
Fix performance of the 'Zapoj se' page

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Czech Python community homepage.
 
 ## Installation
 
-The code is **Python 3**.
+The code is **Python 3** (the production Python version is 3.4).
 
 ```sh
 $ pip install -r requirements.txt

--- a/pythoncz/models/github.py
+++ b/pythoncz/models/github.py
@@ -104,6 +104,7 @@ def _format_issue(org_name, repository, issue, is_pull_request=False):
         'repository_url_html': repository['url'],
         'organization_name': org_name,
         'comments': issue['comments']['totalCount'],
+        'participants': issue['participants']['totalCount'],
         'votes': _get_reactions(issue),
         'labels': labels,
         'coach': 'coach' in labels,

--- a/pythoncz/models/github_get_issues.graphql
+++ b/pythoncz/models/github_get_issues.graphql
@@ -1,0 +1,69 @@
+query($org_name:String!) {
+  organization(login:$org_name) {
+    repositories(first:100) {
+      totalCount
+      nodes {
+        name
+        nameWithOwner
+        isPrivate
+        url
+        issues(first:100, states:OPEN) {
+          totalCount
+          nodes {
+            title
+            url
+            updatedAt
+            author {
+              login
+              url
+            }
+            labels(first:5) {
+              nodes {
+                name
+              }
+            }
+            reactions(first:50) {
+              nodes {
+                content
+              }
+            }
+            comments {
+              totalCount
+            }
+            participants {
+              totalCount
+            }
+          }
+        }
+        pullRequests(first:100, states:OPEN) {
+          totalCount
+          nodes {
+            title
+            url
+            updatedAt
+            author {
+              login
+              url
+            }
+            labels(first:5) {
+              nodes {
+                name
+              }
+            }
+            reactions(first:50) {
+              nodes {
+                content
+              }
+            }
+            comments {
+              totalCount
+            }
+            participants {
+              totalCount
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/pythoncz/templates/get_involved_cs.html
+++ b/pythoncz/templates/get_involved_cs.html
@@ -156,7 +156,7 @@
     <div class="row">
         <div class="col-md-8 col-md-offset-2">
             <p>
-                Pro organizaci jednorázových úkolů používáme <a href="https://github.com/pyvec/zapojse/">GitHub</a> Když nic, tak aspoň <a href="https://github.com/blog/2119-add-reactions-to-pull-requests-issues-and-comments">hlasuj</a> nebo <a href="https://github.com/pyvec/zapojse/issues/new">přidej vlastní nápad</a>. Díky hlasům budeme mít přinejmenším přehled o tom, co si přeje nejvíc lidí.
+                Pro organizaci jednorázových úkolů používáme <a href="https://github.com/pyvec/zapojse/">GitHub</a>. Když nic, tak aspoň <a href="https://github.com/blog/2119-add-reactions-to-pull-requests-issues-and-comments">hlasuj</a> nebo <a href="https://github.com/pyvec/zapojse/issues/new">přidej vlastní nápad</a>. Díky hlasům budeme mít přinejmenším přehled o tom, co si přeje nejvíc lidí.
             </p>
             <p>
                 Značka <span class="label label-primary">Kouč pomůže!</span> znamená, že někdo navrhl, že ti s úkolem pomůže, pokud se do něj pustíš. Jestli se ty chceš někde navrhnout jako kouč, napiš to do komentáře pod daný úkol a <a href="https://help.github.com/articles/applying-labels-to-issues-and-pull-requests/">přiřaď mu štítek</a> <strong>„coach“</strong>.
@@ -191,13 +191,14 @@
                 </span>
             </h3>
             <p class="issue-details">
-                <a href="{{ issue.user.html_url }}" class="label label-default" title="od {{ issue.user.login }}">
-                    <i class="fa fa-user"></i>{{ issue.user.login }}
-                </a>
-                {% if issue.assignee %}
-                <a href="{{ issue.assignee.html_url }}" class="label label-default" title="prý to vyřeší {{ issue.assignee.login }}">
-                    <i class="fa fa-user-circle-o"></i>{{ issue.assignee.login }}
-                </a>
+                {% if issue.user.login %}
+                    <a href="{{ issue.user.html_url }}" class="label label-default" title="od {{ issue.user.login }}">
+                        <i class="fa fa-user"></i>{{ issue.user.login }}
+                    </a>
+                {% else %}
+                    <a href="{{ issue.user.html_url }}" class="label label-default" title="od již neexistujícího uživatele">
+                        <i class="fa fa-user"></i>?
+                    </a>
                 {% endif %}
                 {% if issue.votes %}
                 <span class="label label-default" title="hlasů: {{ issue.votes }}">

--- a/pythoncz/templates/get_involved_cs.html
+++ b/pythoncz/templates/get_involved_cs.html
@@ -200,6 +200,11 @@
                         <i class="fa fa-user"></i>?
                     </a>
                 {% endif %}
+                {% if issue.participants %}
+                <span class="label label-default" title="účastníků diskuze: {{ issue.participants }}">
+                    <i class="fa fa-users"></i>{{ issue.participants }}
+                </span>
+                {% endif %}
                 {% if issue.votes %}
                 <span class="label label-default" title="hlasů: {{ issue.votes }}">
                     <i class="fa fa-thumbs-up"></i>{{ issue.votes }}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,7 @@
 Flask==0.12
 flake8==3.2.1
 pytest==3.0.6
-requests==2.13.0
+requests==2.18.3
 czech-sort==0.4
 PyYAML==3.12
 python-slugify==1.2.1
-grequests==0.3.0


### PR DESCRIPTION
Using GitHub's new [GraphQL API (v4)](https://developer.github.com/v4/), the page can now perform just two HTTP requests (for each GitHub organization) instead of requesting each GitHub issue separately.

I removed assignee, because there can be more then one now and I wasn't sure about how important the information is. Added participants instead.

There are no tests, because I did not have time to add them. Working with GraphQL was rather exploration & prototyping and as soon as I have something working, I'm sending it as a Pull Request, because anything is better then what's on the page right now (503 HTTP error). Whoever wants to add tests, using [responses](https://github.com/getsentry/responses) would probably be a smart choice.