### PR TITLE
Add Dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+.git
+__pycache__
+*.egg-info

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,31 @@
+# This Dockerfile allows you to run python.cz website easily and without
+# issues with dependencies - locally, on your server or in cloud like now.sh.
+# That's handy for testing or for demonstration of new feature in a pull request.
+#
+# For running the website locally:
+#
+#     docker build -t python.cz .
+#     docker run -p 8000:8000 python.cz
+#
+# ...and open in your browser: http://localhost:8000
+#
+# Environment variables can be specified too>
+#
+#     docker run -p 8000:8000 -e GITHUB_TOKEN=token123 python.cz
+
+FROM python:3.4-alpine
+
+RUN python3 -m venv /venv
+RUN /venv/bin/pip install gunicorn
+WORKDIR /app
+COPY . ./
+RUN /venv/bin/pip install -e .
+
+EXPOSE 8000
+
+CMD [ \
+  "/venv/bin/gunicorn", \
+  "--bind", "0.0.0.0:8000", \
+  "--workers", "4", \
+  "pythoncz:app" \
+]


### PR DESCRIPTION
Navrhuji přidat Dockerfile, aby šla celá webovka snadno kamkoli nasadit. Třeba když chci v pull requestu ukázat, jak ty úpravy vypadají naživo, tak díky přitomnosti Dockerfile vše nasadím jedním příkazem např. na [now.sh](https://zeit.co/now) - ukázka: https://pythoncz-ctzpppsnwd.now.sh/ Nebo úplně stejně ji kdokoli rozjede u sebe, na svém virtálním serveru...

Akorát teda nefunguje stránka Zapoj se, zase nechci publikovat svůj Github token. Možná by šlo udělat nějakou kešovací proxy na python.cz nebo na AWS lambdě nebo tak někde, která by tyhle data zprostředkovávala všem takovým adhoc a lokálním instancím, ale to už je mimo scope tohoto PR.