### PR TITLE
Changed link to pep8

### DIFF
--- a/pythoncz/templates/beginners_cs.html
+++ b/pythoncz/templates/beginners_cs.html
@@ -163,7 +163,7 @@
             Konvence pro psaní kódu
         </h3>
         <ul>
-            <li><a href="http://www.python.org/dev/peps/pep-0008/">Style Guide for Python Code</a></li>
+            <li><a href="http://pep8.org/">Style Guide for Python Code</a></li>
             <li><a href="http://www.python.org/dev/peps/pep-0257/">Python Docstring Conventions</a></li>
             <li><a href="https://google.github.io/styleguide/pyguide.html">Google Python Style Guide</a></li>
         </ul>

--- a/pythoncz/templates/beginners_cs.html
+++ b/pythoncz/templates/beginners_cs.html
@@ -163,7 +163,7 @@
             Konvence pro psaní kódu
         </h3>
         <ul>
-            <li><a href="http://pep8.org/">Style Guide for Python Code</a></li>
+            <li><a href="https://pep8.org/">Style Guide for Python Code</a></li>
             <li><a href="http://www.python.org/dev/peps/pep-0257/">Python Docstring Conventions</a></li>
             <li><a href="https://google.github.io/styleguide/pyguide.html">Google Python Style Guide</a></li>
         </ul>


### PR DESCRIPTION
PEP8 na python.org neni uplne citelny. Myslim, ze by byl lepsi link na stranku pep8.org :).