### PR TITLE
Fix materials link and description

### DIFF
--- a/pythoncz/templates/beginners_cs.html
+++ b/pythoncz/templates/beginners_cs.html
@@ -48,7 +48,7 @@
                             Chci umět obecně programovat
                         </div>
                         <div class="panel-footer">
-                            <a href="http://pyladies.cz/course.html" class="btn btn-primary">Materiály od PyLadies</a>
+                            <a href="http://naucse.python.cz/course/pyladies/" class="btn btn-primary">Materiály pro začátečníky</a>
                         </div>
                     </div>
                 </div>


### PR DESCRIPTION
First of all, http://pyladies.cz/course.html leads to a deprecated version of materials.

While we are here I've also changed the link title to be more accurate.

I can [only change the link target](https://github.com/pyvec/python.cz/pull/243) if the second part is considered problematic.