### PR TITLE
Noví zaměstnavatelé na mapce

### DIFF
--- a/pythoncz/static/data/business.geojson
+++ b/pythoncz/static/data/business.geojson
@@ -285,8 +285,8 @@
                 "company": true
             },
             "geometry": {
-                "type": "Point",
-                "coordinates": [14.4009400, 50.0710808]
+                "type": "MultiPoint",
+                "coordinates": [[14.4009400, 50.0710808], [18.2722244, 49.8162225], [16.5990161, 49.1718178]]
             }
         },
         {
@@ -781,8 +781,8 @@
                 "company": true
             },
             "geometry": {
-                "type": "Point",
-                "coordinates": [14.3755908, 50.0806400]
+                "type": "MultiPoint",
+                "coordinates": [[14.3755908, 50.0806400], [18.2618453, 49.8317611]]
             }
         },
         {
@@ -855,6 +855,42 @@
             "geometry": {
                 "type": "Point",
                 "coordinates": [14.4568872, 50.1028653]
+            }
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "name": "OKIN BPS",
+                "url": "https://okinbps.com/us/home/",
+                "company": true
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [18.2923319, 49.8392964]
+            }
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "name": "AutoCont CZ a. s.",
+                "url": "http://www.autocont.cz/",
+                "company": true
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [18.2715000, 49.8410000]
+            }
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "name": "REMAK a.s.",
+                "url": "http://www.remak.eu/cs/",
+                "company": true
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [18.1154847, 49.4607186]
             }
         }        
     ]

--- a/pythoncz_tests/static/data/geojson_europe_test.py
+++ b/pythoncz_tests/static/data/geojson_europe_test.py
@@ -23,6 +23,7 @@ def generate_geojson_entries(filenames):
             yield {
                 'filename': filename,
                 'name': feature['properties']['name'],
+                'geometry_type': feature['geometry']['type'],
                 'coords': feature['geometry']['coordinates'],
             }
 
@@ -52,6 +53,12 @@ def test_geojson_coords_are_in_europe(entry):
 
     (which is Prague) in your GeoJSON entry.
     """
-    coords = entry['coords']
-    for i, coord in enumerate(coords):
-        assert BOUNDS[i][0] < coords[i] < BOUNDS[i][1]
+    # For Point, convert list of coords to nested list
+    if entry['geometry_type'] == 'Point':
+        places = [entry['coords']]
+    else:
+        places = entry['coords']
+
+    for place_coords in places:
+        for i, coord in enumerate(place_coords):
+            assert BOUNDS[i][0] < place_coords[i] < BOUNDS[i][1]


### PR DESCRIPTION
Chtěl jsem přidat pár firem na mapku zaměstnavatelů podle nalezených inzerátů, ale přitom je neduplikovat. Naštěstí geojson podporuje multipoint, což by mohlo být řešením pro https://github.com/pyvec/python.cz/issues/245

Adekvátně tomu jsem upravil i testy.

Omlouvám se za merge commity navíc, ale naposledy jsem přispíval na python.cz před třemi lety a nevím, jak se jich zbavit. Můžete je někdo prosím výhodit?