### PR TITLE
Make the issue list work again

### DIFF
--- a/pythoncz/models/github.py
+++ b/pythoncz/models/github.py
@@ -119,13 +119,19 @@ def _format_issue(org_name, repository, issue, is_pull_request=False):
 
 
 def _calculate_votes(issue):
-    votes = 0
-    for reaction in _get_nodes(issue, 'reactions'):
-        if reaction['content'] in ['THUMBS_DOWN', 'CONFUSED']:
-            votes -= 1
-        else:
-            votes += 1
-    return votes
+    """Get votes per issue from counts of Reactions
+
+    A THUMBS_DOWN and CONFUSED counts as "-1", the rest as "+1".
+    """
+    # From the query we get the total number of reactions (including
+    # the "downvotes"), and the number of THUMBS_DOWN, and the number
+    # of CONFUSED.
+
+    return (
+        issue['reactions']['totalCount']
+        - issue['thumbs_down']['totalCount'] * 2
+        - issue['confuseds']['totalCount'] * 2
+    )
 
 
 def _get_nodes(node, connection_name):

--- a/pythoncz/models/github_get_issues.graphql
+++ b/pythoncz/models/github_get_issues.graphql
@@ -17,15 +17,19 @@ query($org_name:String!) {
               login
               url
             }
-            labels(first:5) {
+            labels(first:20) {
               nodes {
                 name
               }
             }
-            reactions(first:50) {
-              nodes {
-                content
-              }
+            reactions() {
+              totalCount
+            }
+            thumbs_down:reactions(content:THUMBS_DOWN) {
+              totalCount
+            }
+            confuseds:reactions(content:CONFUSED) {
+              totalCount
             }
             comments {
               totalCount
@@ -45,15 +49,19 @@ query($org_name:String!) {
               login
               url
             }
-            labels(first:5) {
+            labels(first:20) {
               nodes {
                 name
               }
             }
-            reactions(first:50) {
-              nodes {
-                content
-              }
+            reactions() {
+              totalCount
+            }
+            thumbs_down:reactions(content:THUMBS_DOWN) {
+              totalCount
+            }
+            confuseds:reactions(content:CONFUSED) {
+              totalCount
             }
             comments {
               totalCount

--- a/pythoncz_tests/models/github_test_fixtures.py
+++ b/pythoncz_tests/models/github_test_fixtures.py
@@ -75,6 +75,15 @@ def issue(pr=False, labels=None, reactions_counts=None):
             random.sample(labels_fake_values, labels_count)
         ]
 
+    if reactions_counts is None:
+        reaction_count = random.randint(0, 4242)
+        thumbsdown_count = random.randint(0, reaction_count)
+        confused_count = random.randint(0, reaction_count - thumbsdown_count)
+    else:
+        reaction_count = sum(reactions_counts.values())
+        thumbsdown_count = reactions_counts.get('THUMBS_DOWN', 0)
+        confused_count = reactions_counts.get('CONFUSED', 0)
+
     return {
         'title': title,
         'url': url,
@@ -84,24 +93,9 @@ def issue(pr=False, labels=None, reactions_counts=None):
             'url': 'https://github.com/{}'.format(author),
         },
         'labels': {'nodes': labels},
-        'reactions': {'nodes': reactions(reactions_counts)},
+        'reactions': {'totalCount': reaction_count},
+        'thumbs_down': {'totalCount': thumbsdown_count},
+        'confuseds': {'totalCount': confused_count},
         'comments': {'totalCount': random.randint(1, 4242)},
         'participants': {'totalCount': random.randint(1, 42)},
     }
-
-
-def reactions(reactions_counts=None):
-    if reactions_counts is None:
-        reaction_types = random.sample([
-            'THUMBS_UP', 'THUMBS_DOWN', 'LAUGH', 'HOORAY', 'CONFUSED', 'HEART'
-        ], random.randint(0, 6))
-        reactions_counts = {}
-        for reaction_type in reaction_types:
-            reactions_counts[reaction_type] = random.randint(1, 42)
-    if reactions_counts:
-        reactions = []
-        for reaction_type, count in reactions_counts.items():
-            for i in range(count):
-                reactions.append({'content': reaction_type})
-        return reactions
-    return []


### PR DESCRIPTION
GitHub's GraphQL has limits on the maximum possible numbers of
returned nodes, which python.cz was exceeding by getting 50
reactions per issue (× 100 issues × 100 repositories).

Summarize the reactions by only getting the total number and
totals of the "downvoting" ones.

This lets us bump the number of labels per issue from 5 to 20.

Same for pull requests.

Fixes: https://github.com/pyvec/python.cz/issues/250