### PR TITLE
De-emphasize tentative events

### DIFF
--- a/pythoncz/static/main.css
+++ b/pythoncz/static/main.css
@@ -570,7 +570,8 @@ i.icon-english::before {
     text-align: center;
     border: 1px #337ab7 solid;
     border-radius: 0.3em;
-    padding: 0.3em 2em 1em 2em;
+    min-width: 8em;  /* sized for "WEDNESDAY" */
+    padding: 0.3em 1em 1em 1em;
 }
 
 .event-day,

--- a/pythoncz/static/main.css
+++ b/pythoncz/static/main.css
@@ -650,6 +650,19 @@ i.icon-english::before {
     border-color: #AAA;
 }
 
+.event-tentative .event-datetime {
+    padding-bottom: 0.5em;
+}
+
+.event-tentative .event-day {
+    font-size: 180%;
+}
+
+.event-tentative .event-weekday,
+.event-tentative .event-time {
+    display: inline;
+}
+
 .meetups {
     margin: 2em 0;
 }

--- a/pythoncz/templates/_events.html
+++ b/pythoncz/templates/_events.html
@@ -7,7 +7,7 @@
             <div class="media-left">
                 <time class="event-datetime media-object" datetime="{{ event.event.begin|format_dt_iso }}">
                     <span class="event-day">{{ event.event.begin|format_dt('%d')|safe }}</span>
-                    <small class="event-weekday">{{ event.event.begin|format_dt('%w')|int|format_weekday }}</small>
+                    <small class="event-weekday">{{ event.event.begin|format_dt('%w')|int|format_weekday(lang=lang) }}</small>
                     <small class="event-time">{{ event.event.begin|format_dt('%H:%M') }}</small>
                 </time>
             </div>

--- a/pythoncz/templates/_events.html
+++ b/pythoncz/templates/_events.html
@@ -7,8 +7,18 @@
             <div class="media-left">
                 <time class="event-datetime media-object" datetime="{{ event.event.begin|format_dt_iso }}">
                     <span class="event-day">{{ event.event.begin|format_dt('%d')|safe }}</span>
-                    <small class="event-weekday">{{ event.event.begin|format_dt('%w')|int|format_weekday(lang=lang) }}</small>
-                    <small class="event-time">{{ event.event.begin|format_dt('%H:%M') }}</small>
+                    {% if 'tentative-date' in event.event.categories %}
+                        <small class="event-weekday">
+                            {{ event.event.begin|format_dt('%w')|int|format_weekday_short(lang=lang) }}
+                        </small>
+                    {% else %}
+                        <small class="event-weekday">
+                            {{ event.event.begin|format_dt('%w')|int|format_weekday(lang=lang) }}
+                        </small>
+                    {% endif %}
+                    <small class="event-time">
+                        {{ event.event.begin|format_dt('%H:%M') }}
+                    </small>
                 </time>
             </div>
             <div class="media-body">

--- a/pythoncz/views.py
+++ b/pythoncz/views.py
@@ -65,6 +65,13 @@ def format_weekday_filter(weekday, lang='cs'):
     return weekdays[lang][weekday]
 
 
+@app.template_filter('format_weekday_short')
+def format_weekday_short_filter(weekday, lang='cs'):
+    weekdays = {'en': ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'],
+                'cs': ['ne', 'po', 'út', 'st', 'čt', 'pá', 'so']}
+    return weekdays[lang][weekday]
+
+
 @app.context_processor
 def inject_context():
     return {


### PR DESCRIPTION
- In the English version, use English weekday names 
- Make boxes for tentative events smaller