### PR TITLE
Replace werkzeug.contrib with cachelib

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -22,6 +22,7 @@ ics = "==0.4"
 arrow = "==0.4.2"
 lxml = "==4.5.0"
 cssselect = "==1.1.0"
+cachelib = "*"
 
 [dev-packages]
 pylama = "==7.7.1"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "024534e1634b1aecc0f77f6c7c3a299c015e617d190a7c94a873ff92a2f16b08"
+            "sha256": "f6f6f11143189dff6396a98db874943dda170809a9d3811b377af6b9516db4b5"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -22,6 +22,14 @@
             ],
             "index": "pypi",
             "version": "==0.4.2"
+        },
+        "cachelib": {
+            "hashes": [
+                "sha256:1c79bb1e83b339fa4e65c8281b9e5311027540c76516ee98a66c151e629e37f1",
+                "sha256:8b889b509d372095357b8705966e1282d40835c4126d7c2b07fd414514d8ae8d"
+            ],
+            "index": "pypi",
+            "version": "==0.1"
         },
         "certifi": {
             "hashes": [
@@ -114,10 +122,10 @@
         },
         "jinja2": {
             "hashes": [
-                "sha256:6e7a3c2934694d59ad334c93dd1b6c96699cf24c53fdb8ec848ac6b23e685734",
-                "sha256:d6609ae5ec3d56212ca7d802eda654eaf2310000816ce815361041465b108be4"
+                "sha256:93187ffbc7808079673ef52771baa950426fd664d3aad1d0fa3e95644360e250",
+                "sha256:b0eaf100007721b5c16c1fc1eecb87409464edc10469ddc9a22a27a99123be49"
             ],
-            "version": "==2.11.0"
+            "version": "==2.11.1"
         },
         "lxml": {
             "hashes": [
@@ -252,10 +260,10 @@
         },
         "werkzeug": {
             "hashes": [
-                "sha256:1e0dedc2acb1f46827daa2e399c1485c8fa17c0d8e70b6b875b4e7f54bf408d2",
-                "sha256:b353856d37dec59d6511359f97f6a4b2468442e454bd1c98298ddce53cac1f04"
+                "sha256:169ba8a33788476292d04186ab33b01d6add475033dfc07215e6d219cc077096",
+                "sha256:6dc65cf9091cf750012f56f2cad759fa9e879f511b5ff8685e456b4e3bf90d16"
             ],
-            "version": "==0.16.1"
+            "version": "==1.0.0"
         }
     },
     "develop": {
@@ -478,10 +486,10 @@
         },
         "zipp": {
             "hashes": [
-                "sha256:ccc94ed0909b58ffe34430ea5451f07bc0c76467d7081619a454bf5c98b89e28",
-                "sha256:feae2f18633c32fc71f2de629bfb3bd3c9325cd4419642b1f1da42ee488d9b98"
+                "sha256:12248a63bbdf7548f89cb4c7cda4681e537031eda29c02ea29674bc6854460c2",
+                "sha256:7c0f8e91abc0dc07a5068f315c52cb30c66bfbc581e5b50704c8a2f6ebae794a"
             ],
-            "version": "==2.1.0"
+            "version": "==3.0.0"
         }
     }
 }

--- a/pythoncz/models/github.py
+++ b/pythoncz/models/github.py
@@ -4,7 +4,7 @@ import warnings
 from datetime import datetime
 
 import requests
-from werkzeug.contrib.cache import FileSystemCache
+from cachelib import FileSystemCache
 
 from pythoncz import app
 

--- a/tests/models/github_test.py
+++ b/tests/models/github_test.py
@@ -4,7 +4,7 @@ import warnings
 import pytest
 import requests
 import responses
-from werkzeug.contrib.cache import NullCache
+from cachelib import NullCache
 
 from pythoncz import app
 from pythoncz.models import github as github_module

--- a/tests/views_test.py
+++ b/tests/views_test.py
@@ -3,7 +3,7 @@ from urllib.parse import quote_plus as url_quote_plus
 import ics
 import pytest
 from flask import url_for
-from werkzeug.contrib.cache import NullCache
+from cachelib import NullCache
 
 from pythoncz import app
 from pythoncz.models import github as github_module


### PR DESCRIPTION
In version 1.0 the contrib part of werkzeug has been completely removed. The caching utilities has been moved to a package called cachelib.