### PR TITLE
.travis.yml: Use skip_cleanup rather than cleanup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ after_success:
     - "pipenv run coveralls"
 deploy:
     provider: "script"
-    cleanup: false
+    skip_cleanup: true
     script: "pipenv run deploy"
     on:
         branch: "master"


### PR DESCRIPTION
The [Travis docs](https://docs.travis-ci.com/user/deployment/) and [Elsa docs](https://github.com/pyvec/elsa/blob/master/README.rst#travis-ci-based-deployment) have `skip_cleanup`.

As far as I can see, this was changed in https://github.com/pyvec/python.cz/pull/404, which removed the config for [dpl v1](https://docs.travis-ci.com/user/deployment/) without switching to [dpl v2 beta](https://docs.travis-ci.com/user/deployment-v2).