### PR TITLE
zapojse: limit the GraphQL query

### DIFF
--- a/pythoncz/models/github_get_issues.graphql
+++ b/pythoncz/models/github_get_issues.graphql
@@ -1,13 +1,13 @@
 query($org_name:String!) {
   organization(login:$org_name) {
-    repositories(first:50) {
+    repositories(first:20, isLocked:false, privacy:PUBLIC, orderBy:{direction:DESC, field:PUSHED_AT}) {
       totalCount
       nodes {
         name
         nameWithOwner
         isPrivate
         url
-        issues(first:50, states:OPEN) {
+        issues(first:20, states:OPEN, orderBy:{direction:DESC, field:UPDATED_AT}) {
           totalCount
           nodes {
             title
@@ -39,7 +39,7 @@ query($org_name:String!) {
             }
           }
         }
-        pullRequests(first:50, states:OPEN) {
+        pullRequests(first:20, states:OPEN, orderBy:{direction:DESC, field:UPDATED_AT}) {
           totalCount
           nodes {
             title


### PR DESCRIPTION
- Limit all the collections to first 20 items.
  GitHub paginates by 20 items; unless we follow that we might as well
  limit the query.
- Exclude locked (archived) and private repositories
- Order things by last update date, so we hopefully get relevant ones in
  cases when some are hidden. (It's not possible to order by "popularity",
  see: https://docs.github.com/en/graphql/reference/enums#issueorderfield )