### PR TITLE
Reorder and update links

### DIFF
--- a/pythoncz/templates/_communication.html
+++ b/pythoncz/templates/_communication.html
@@ -3,6 +3,22 @@
 
 <ul class="communication">
     <li class="communication-item">
+        <a href="https://www.facebook.com/groups/pyonieri/">
+            <span class="communication-item-icon"><i class="fab fa-facebook"></i></span>
+            <span class="communication-item-caption">
+                {% if lang == 'cs' %}Skupina Pyonýři{% else %}Group Pyoneers{% endif %}
+            </span>
+        </a>
+    </li>
+    <li class="communication-item">
+        <a href="https://discord.gg/yUbgArVAyF">
+            <span class="communication-item-icon"><i class="fab fa-discord"></i></span>
+            <span class="communication-item-caption">
+                Discord
+            </span>
+        </a>
+    </li>
+    <li class="communication-item">
         <a href="https://groups.google.com/group/django-cs/">
             <span class="communication-item-icon"><i class="fa fa-envelope"></i></span>
             <span class="communication-item-caption">
@@ -15,14 +31,6 @@
             <span class="communication-item-icon"><i class="fa fa-envelope"></i></span>
             <span class="communication-item-caption">
                 {% if lang == 'cs' %}E-mailová skupina na{% else %}Mailgroup at{% endif %} py.cz
-            </span>
-        </a>
-    </li>
-    <li class="communication-item">
-        <a href="https://www.facebook.com/groups/pyonieri/">
-            <span class="communication-item-icon"><i class="fab fa-facebook"></i></span>
-            <span class="communication-item-caption">
-                {% if lang == 'cs' %}Skupina Pyonýři{% else %}Group Pyoneers{% endif %}
             </span>
         </a>
     </li>
@@ -43,26 +51,18 @@
         </a>
     </li>
     <li class="communication-item">
+        <a href="https://twitter.com/PyLadiesCZ">
+            <span class="communication-item-icon"><i class="fab fa-twitter"></i></span>
+            <span class="communication-item-caption">
+                PyLadies CZ
+            </span>
+        </a>
+    </li>
+    <li class="communication-item">
         <a href="https://twitter.com/PyDataPrague">
             <span class="communication-item-icon"><i class="fab fa-twitter"></i></span>
             <span class="communication-item-caption">
                 {% if lang == 'cs' %}PyData Praha{% else %}PyData Prague{% endif %}
-            </span>
-        </a>
-    </li>
-    <li class="communication-item">
-        <a href="https://twitter.com/Pyvec">
-            <span class="communication-item-icon"><i class="fab fa-twitter"></i></span>
-            <span class="communication-item-caption">
-                {% if lang == 'cs' %}Neziskovka Pyvec{% else %}Nonprofit Pyvec{% endif %}
-            </span>
-        </a>
-    </li>
-    <li class="communication-item">
-        <a href="http://pyvec.slack.com/">
-            <span class="communication-item-icon"><i class="fab fa-slack"></i></span>
-            <span class="communication-item-caption">
-                {% if lang == 'cs' %}Organizační Slack{% else %}Slack for organizers{% endif %}
             </span>
         </a>
     </li>
@@ -83,10 +83,10 @@
         </a>
     </li>
     <li class="communication-item">
-        <a href="https://discord.gg/yUbgArVAyF">
-            <span class="communication-item-icon"><i class="fab fa-discord"></i></span>
+        <a href="http://pyvec.slack.com/">
+            <span class="communication-item-icon"><i class="fab fa-slack"></i></span>
             <span class="communication-item-caption">
-                Discord
+                {% if lang == 'cs' %}Slack pro organizátory{% else %}Slack for organizers{% endif %}
             </span>
         </a>
     </li>


### PR DESCRIPTION
1. Pyonýři (IMHO most mainstream)
2. Discord (shiny new stuff)
3. e-mail groups (still surviving)
4. twitter accounts
5. irc channels (almost dead? IDK)
6. slack (invite-only, for orgs/admins/mods, not interesting that much for regular community members)

Also, I've removed Pyvec Twitter as it's not very interesting and maintained. I've replaced it with PyLadies CZ Twitter.