### PR TITLE
Added Leadspicker to business.geojson

### DIFF
--- a/pythoncz/static/data/business.geojson
+++ b/pythoncz/static/data/business.geojson
@@ -670,6 +670,18 @@
                 "coordinates": [14.4036089, 50.0751008]
             }
         },
+	{
+            "type": "Feature",
+            "properties": {
+                "name": "Leadspicker s.r.o.",
+                "url": "https://leadspicker.com/",
+                "company": true
+            },
+            "geometry": {
+                "type": "Point",
+                "coordinates": [14.4262344, 50.0907506]
+            }
+        },
         {
             "type": "Feature",
             "properties": {


### PR DESCRIPTION
At Leadspicker we have almost all code in Python (Django) and we are always looking for pythonistas :)

We are struggling a bit with HR (do not currently have dedicated person for that) and our advert on StartupJobs expired (again), so I have only this link for now https://www.startupjobs.cz/nabidka/30347/python-django-developer-wanted