### PR TITLE
Add navolnenoze.cz link to hiring guide (#335)

### DIFF
--- a/docs/prace.md
+++ b/docs/prace.md
@@ -36,6 +36,9 @@ CERNu**.
     [StartupJobs.cz](https://www.startupjobs.cz/nabidky/15/python-programmer),
     ... (Víš o dalších? [Přidej
     odkaz!](https://github.com/pyvec/python.cz/edit/master/pythoncz/static/data/jobs.yml))
+-   Projdi si [katalog Python freelancerů na
+    NaVolneNoze.cz](https://navolnenoze.cz/katalog/python/) – můžeš
+    přímo oslovit nezávislé profesionály.
 -   Odzkoušej si své znalosti v testech:
     [StartupJobs.cz](https://www.startupjobs.cz/test/python),
     [Toptal.com](http://www.toptal.com/python/interview-questions),


### PR DESCRIPTION
## Summary

Adds a link to navolnenoze.cz/katalog/python/ in the "Jak najít Python
programátory?" section of `docs/prace.md`, as requested in #335.

## Changes

- Added a bullet point linking to the NaVolneNoze.cz Python freelancer catalog
  in the employer-facing hiring guide

## Related Issue

Closes #335

## Testing

- Verified locally with `poetry run mkdocs serve` — page renders correctly
- Confirmed that https://navolnenoze.cz/katalog/python/ is live and lists
  20+ Python professionals